### PR TITLE
Add empty message check

### DIFF
--- a/src/log4cr.cr
+++ b/src/log4cr.cr
@@ -57,7 +57,7 @@ module Log4cr
       end
 
       protected def {{threshold.id}}(message : String, child_category)
-        if {{threshold.id}}?
+        if !message.empty? && {{threshold.id}}?
           all_appenders.each do |appender|
             appender.{{threshold.id}} message, child_category
           end


### PR DESCRIPTION
Don't print or do anything with a message that is empty. This prevents empty lines being logged when the user may not expect logging to happen.