### PR TITLE
Grandparent loggers do not receive messages

### DIFF
--- a/spec/logger_spec.cr
+++ b/spec/logger_spec.cr
@@ -101,6 +101,16 @@ describe Log4cr::Logger do
       io.empty?.should be_false
     end
 
+    it "logs to its grandparent(s)" do
+      io = IO::Memory.new
+      appender = Log4cr::Appender.new io
+      logger = Log4cr::Logger.get "a"
+      logger.add_appender appender
+      Log4cr::Logger.get("a.b.c").info "a message"
+
+      io.empty?.should be_false
+    end
+
     it "can log to both itself and its parent" do
       io = IO::Memory.new
       appender = Log4cr::Appender.new io

--- a/src/log4cr.cr
+++ b/src/log4cr.cr
@@ -33,7 +33,7 @@ module Log4cr
     end
 
     def all_appenders
-      appenders + parent.appenders
+      appenders + parent.all_appenders
     end
 
     {% for threshold in %i(debug info warn error fatal) %}


### PR DESCRIPTION
Unless this is desired behavior, messages should travel all the way up the inheritance chain, to the root.